### PR TITLE
Remove Groups from MsgUpdateDeployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akashlytics-deploy",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/shared/protoTypes/v1beta2.js
+++ b/src/shared/protoTypes/v1beta2.js
@@ -66,8 +66,6 @@ export const MsgCreateDeployment = new Type("MsgCreateDeployment")
 export const MsgUpdateDeployment = new Type("MsgUpdateDeployment")
   .add(new Field("id", 1, "DeploymentID"))
   .add(DeploymentID)
-  .add(new Field("groups", 2, "GroupSpec", "repeated"))
-  .add(GroupSpec)
   .add(new Field("version", 3, "bytes"));
 
 export const MsgDepositDeployment = new Type("MsgDepositDeployment")

--- a/src/shared/utils/TransactionMessageData.js
+++ b/src/shared/utils/TransactionMessageData.js
@@ -110,7 +110,6 @@ export class TransactionMessageData {
       typeUrl: TransactionMessageData.Types.MSG_UPDATE_DEPLOYMENT.type,
       value: {
         id: deploymentData.deploymentId,
-        groups: deploymentData.groups,
         version: deploymentData.version
       }
     };


### PR DESCRIPTION
Removing `groups` property from MsgUpdateDeployment. (Same as https://github.com/ovrclk/akash/commit/0240b93a381aaf1f535e57a318e5a534f7e7a194)