### PR TITLE
Make MonacoEditor readonly

### DIFF
--- a/src/routes/TemplateDetails/TemplateDetails.js
+++ b/src/routes/TemplateDetails/TemplateDetails.js
@@ -98,7 +98,7 @@ export function TemplateDetails() {
       )}
       {activeTab === "SDL" && (
         <ViewPanel bottomElementId="footer" overflow="hidden">
-          <MonacoEditor height="100%" language="yaml" theme="vs-dark" value={template.deploy} options={monacoOptions} />
+          <MonacoEditor height="100%" language="yaml" theme="vs-dark" value={template.deploy} options={{ ...monacoOptions, readOnly: true }} />
         </ViewPanel>
       )}
       {activeTab === "GUIDE" && (


### PR DESCRIPTION
- Make the SDL code readonly when viewing a template