### PR TITLE
update averageBlockTime

### DIFF
--- a/src/shared/utils/priceUtils.js
+++ b/src/shared/utils/priceUtils.js
@@ -2,7 +2,7 @@ import add from "date-fns/add";
 import { averageDaysInMonth } from "./date";
 import { useBlock } from "../../queries";
 
-export const averageBlockTime = 6.174;
+export const averageBlockTime = 6.098;
 
 export function uaktToAKT(amount, precision = 3) {
   return Math.round((amount / 1000000 + Number.EPSILON) * Math.pow(10, precision)) / Math.pow(10, precision);


### PR DESCRIPTION
```
export AKASH_NODE=https://rpc.akash.forbole.com:443

# set SHIFT to 30 day ago in blocks, assuming that block time is 6 seconds sharp
SHIFT=$(echo "(60/6)*60*24*30" | bc)

HEIGHT=$(akash status |& jq -r '.SyncInfo.latest_block_height')

T1="$(akash query block $HEIGHT | jq -r '.block.header.time')"
T2="$(akash query block $((HEIGHT-SHIFT)) | jq -r '.block.header.time')"

T1s=$(date +%s%N -d "$T1")
T2s=$(date +%s%N -d "$T2")

echo "(($T1s-$T2s)/$SHIFT)/10^9" | bc -l
6.09821458440728935185
```

Let me know if that makes sense or if you have better ideas around obtaining a better time?