### PR TITLE
Add note for others processors compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,6 @@ Want to see your application in Akashlytics?  Create a pull request on the [awes
 - Akashlytics Deploy is currently in BETA. We strongly suggest you start with a new wallet and a small amount of AKT until we further stabilize the product.
 - We're not responsible for any loss or damages related to using the app.
 - The app has a high chance of containing bugs since it's in BETA, use at your own risk.
+- [Only x86_64 processors are officially supported for Akash implementations.](https://docs.akash.network/guides/deploy/akashlytics-deploy-installation#cpu-support) But if the docker image is built [setting the target platform to linux/amd64](https://stackoverflow.com/a/69119815/8215759) it [is possible that it will work from others processors](https://github.com/ovrclk/docs/pull/239).
 
 


### PR DESCRIPTION
pull request to modify the docs -> https://github.com/ovrclk/docs/pull/239

---

In the documentation it is clearly stated that [only x86_64 processors are supported for Akash deployments](https://docs.akash.network/guides/deploy/akashlytics-deploy-installation#cpu-support)

But

From a mac with m1 processor I was able to run my deploys to akash network indicating at the moment of building the docker image that the [target platform is linux/amd64.](https://stackoverflow.com/a/69119815/8215759)

---

without specifying that the target platform is linux/amd64 my images did not work

[<img width="782" alt="Screen Shot 2022-07-18 at 04 08 28" src="https://user-images.githubusercontent.com/30802967/179460481-0c49f4c9-9b9b-4822-be63-1f2d52891916.png">](https://hub.docker.com/layers/254934625/sturmenta/validate-purchase-ios/0.0.1/images/sha256-296f65a6309f559baf9320a4107a92428a4b884ed388e7d85908a61b9e3fcde3?context=repo)

after specifying this my docker images work on akash network

[<img width="766" alt="Screen Shot 2022-07-18 at 04 08 44" src="https://user-images.githubusercontent.com/30802967/179460830-e0790d83-10dc-4325-a000-20ed6f4dc13c.png">](https://hub.docker.com/layers/254983102/sturmenta/validate-purchase-ios/0.0.4/images/sha256-228fc2aad1f458a5ec6041417dbc8b2926d4cd3559782d09df9f3950948acd1a?context=repo)